### PR TITLE
WordPressをdocker-composeで構築

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+
+services:
+   db:
+     platform: linux/x86_64
+     image: mysql:5.7
+     volumes:
+       - db_data:/var/lib/mysql
+     restart: always
+     environment:
+       MYSQL_ROOT_PASSWORD: somewordpress
+       MYSQL_DATABASE: wordpress
+       MYSQL_USER: wordpress
+       MYSQL_PASSWORD: wordpress
+
+   wordpress:
+     depends_on:
+       - db
+     image: wordpress:latest
+     ports:
+       - "8000:80"
+     restart: always
+     environment:
+       WORDPRESS_DB_HOST: db:3306
+       WORDPRESS_DB_USER: wordpress
+       WORDPRESS_DB_PASSWORD: wordpress
+volumes:
+    db_data:


### PR DESCRIPTION
## 概要
WordPressをdocker-composeで構築

[参考サイト - クイックスタート](https://docs.docker.jp/compose/wordpress.html)
[参考サイト - M1対応](https://ryotarch.com/docker/no-matching-manifest-for-linux-arm64-v8-on-m1-mac/)